### PR TITLE
correccion nueva consulta

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import url
-from core.views import CIE10Autocomplete, PacienteAutocomplete
+from core.views import (CIE10Autocomplete,
+                        PacienteAutocomplete,
+                        ProfesionalAutocomplete)
 
 
 urlpatterns = [
@@ -12,5 +14,10 @@ urlpatterns = [
         r"^paciente-autocomplete/$",
         PacienteAutocomplete.as_view(),
         name="paciente-autocomplete",
+    ),
+    url(
+        r"^profesional-autocomplete/$",
+        ProfesionalAutocomplete.as_view(),
+        name="profesional-autocomplete",
     ),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,8 @@
 from dal import autocomplete
 from cie10_django.models import CIE10
 from pacientes.models import Paciente
+from profesionales.models import Profesional
+from django.db.models import Q
 
 
 class CIE10Autocomplete(autocomplete.Select2QuerySetView):
@@ -15,7 +17,9 @@ class CIE10Autocomplete(autocomplete.Select2QuerySetView):
         qs = CIE10.objects.all()
 
         if self.q:
-            qs = qs.filter(code__istartswith=self.q)
+            qs = qs.filter(Q(code__istartswith=self.q) |
+                           Q(description__istartswith=self.q)
+                          )
 
         return qs.order_by("code")
 
@@ -30,6 +34,22 @@ class PacienteAutocomplete(autocomplete.Select2QuerySetView):
             return Paciente.objects.none()
 
         qs = Paciente.objects.all()
+
+        if self.q:
+            qs = qs.filter(numero_documento__istartswith=self.q)
+
+        return qs.order_by("apellidos", "nombres")
+
+class ProfesionalAutocomplete(autocomplete.Select2QuerySetView):
+    """
+    Base de autocompletado para profesionales.
+    """
+
+    def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return Profesional.objects.none()
+
+        qs = Profesional.objects.all()
 
         if self.q:
             qs = qs.filter(numero_documento__istartswith=self.q)

--- a/core/views.py
+++ b/core/views.py
@@ -10,6 +10,12 @@ class CIE10Autocomplete(autocomplete.Select2QuerySetView):
     Base de autompletado para códigos de diagnósticos.
     """
 
+    def get_result_label(self, item):
+        return f"{item.code} - {item.description}"
+
+    def get_selected_result_label(self, item):
+        return item.code
+
     def get_queryset(self):
         if not self.request.user.is_authenticated:
             return CIE10.objects.none()

--- a/pacientes/forms.py
+++ b/pacientes/forms.py
@@ -32,7 +32,7 @@ class ConsultaForm(forms.ModelForm):
         queryset=CIE10.objects.all(),
         widget=autocomplete.ModelSelect2Multiple(
             url="cie10-autocomplete",
-            attrs={"data-placeholder": "Ejemplo: A00 o ingrese descripción"}
+            attrs={"data-placeholder": "Ingrese código o descripción"}
         ),
     )
 

--- a/pacientes/forms.py
+++ b/pacientes/forms.py
@@ -38,7 +38,8 @@ class ConsultaForm(forms.ModelForm):
 
     class Meta:
         model = Consulta
-        fields = "__all__"
+        fields = ('paciente', 'profesional', 'codigo', 'diagnostico',
+                  'indicaciones', 'receta', 'practicas', 'derivaciones')
 
     def __init__(self, *args, **kwargs):
         """

--- a/pacientes/forms.py
+++ b/pacientes/forms.py
@@ -2,6 +2,7 @@ from dal import autocomplete
 from django import forms
 from cie10_django.models import CIE10
 from pacientes.models import Consulta, Paciente
+from profesionales.models import Profesional
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 
@@ -17,11 +18,21 @@ class ConsultaForm(forms.ModelForm):
             },
         ),
     )
+    profesional = forms.ModelChoiceField(
+        queryset=Profesional.objects.all(),
+        widget=autocomplete.ModelSelect2(
+            url="profesional-autocomplete",
+            attrs={
+                "data-placeholder": "Ingrese número de documento",
+                "data-minimum-input-length": 3,
+            },
+        ),
+    )
     codigo = forms.ModelMultipleChoiceField(
         queryset=CIE10.objects.all(),
         widget=autocomplete.ModelSelect2Multiple(
             url="cie10-autocomplete",
-            attrs={"data-placeholder": "Ejemplo: A00"}
+            attrs={"data-placeholder": "Ejemplo: A00 o ingrese descripción"}
         ),
     )
 

--- a/profesionales/models.py
+++ b/profesionales/models.py
@@ -26,7 +26,7 @@ class Profesional(Persona):
 
     def __str__(self):
         apellidos = "" if self.apellidos is None else self.apellidos
-        return f"{self.nombres, apellidos}"
+        return f"{apellidos}, {self.nombres}"
 
     def agregar_dato_de_contacto(self, tipo, valor):
         type_ = ContentType.objects.get_for_model(self)


### PR DESCRIPTION
El profesional ahora se rellena autocompletando. Me parece que este campo se debería llenar por defecto con el profesional que esté logueado.
El código se puede buscar por descripción. @avdata99 el __str__ de CIE10 te muestra sólo el código, de alguna forma habría que mostrar parte de la descripción ya que hay muchas descripciones parecidas para códigos diferentes. No tiene mucho sentido ingresar parte de la descripción y que el widget me muestre varios códigos sin descripción, no ayuda en nada a identificarlo.