### PR TITLE
WIP: permisos del menu

### DIFF
--- a/ggg/templates/base_admin.html
+++ b/ggg/templates/base_admin.html
@@ -61,9 +61,7 @@
                 <h3>{{ site_short_title }}</h3>
               </a>
             </div>
-{% if user__es_administrativo %}
-  {% include "menu_lat_admin.html" %}
-{% endif %}          
+          {% include "menu_lat_admin.html" %}
           <ul class="list-unstyled CTAs">
               <li>
                 <a target='_blank' 

--- a/ggg/templates/menu_lat_admin.html
+++ b/ggg/templates/menu_lat_admin.html
@@ -18,6 +18,7 @@ Centro de salud activo
 
 <ul class="list-unstyled components">
     <!--titulo agrupador sin link <p>Profesionales</p>-->
+    {% if perms.profesionales.view_profesional or perms.centros_de_salud.view_profesionalesenservicio %}
     <li class="active">
         <a href="#menu_profesionales" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">Profesionales</a>
         <ul class="collapse list-unstyled" id="menu_profesionales">
@@ -35,7 +36,9 @@ Centro de salud activo
         
         </ul>
     </li>
+    {% endif %}
     
+    {% if perms.profesionales.can_view_tablero or perms.obras_sociales.can_view_tablero or perms.centros_de_salud.can_view_tablero %}
     <li>
         <a href="#menu_tableros" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">Tableros de gestion</a>
         <ul class="collapse list-unstyled" id="menu_tableros">
@@ -68,7 +71,9 @@ Centro de salud activo
 
         </ul>
     </li>
+    {% endif %}
 
+    {% if perms.obras_sociales.view_obrasocial %}
     <!--titulo agrupador sin link <p>Atenciones</p> -->
     <li>
         <!-- menu link suelto <a href="#">Otro Menu principal</a> -->
@@ -82,7 +87,9 @@ Centro de salud activo
             
         </ul>
     </li>
+    {% endif %}
 
+    {% if perms.centros_de_salud.view_centrodesalud or perms.centros_de_salud.view_servicio %}
     <!--titulo agrupador sin link <p>Atenciones</p> -->
     <li>
         <!-- menu link suelto <a href="#">Otro Menu principal</a> -->
@@ -102,7 +109,9 @@ Centro de salud activo
             
         </ul>
     </li>
+    {% endif %}
 
+    {% if perms.centros_de_salud.view_especialidad or perms.especialidades.view_medidaanexa or perms.especialidades.view_medidasanexasespecialidad %}
     <li>
         <!-- menu link suelto <a href="#">Otro Menu principal</a> -->
         <a href="#menu_especialidades" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">Especialidades</a>
@@ -128,7 +137,9 @@ Centro de salud activo
 
         </ul>
     </li>
+    {% endif %}
 
+    {% if perms.calendario.add_turno or perms.calendario.can_schedule_turno or perms.profesionales.add_consulta or perms.calendario.can_view_misturnos %}
     <li>
         <!-- menu link suelto <a href="#">Otro Menu principal</a> -->
         <a href="#menu_turnos" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">Turnos</a>
@@ -158,8 +169,9 @@ Centro de salud activo
         {% endif %}
         </ul>
     </li>
+    {% endif %}
 
-
+    {% if perms.auth.change_user or perms.usuarios.view_usuarioencentrodesalud %}
     <li>
         <!-- menu link suelto <a href="#">Otro Menu principal</a> -->
         <a href="#menu_usuarios" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">Usuarios</a>
@@ -179,13 +191,14 @@ Centro de salud activo
         
         </ul>
     </li>
-    
+    {% endif %}
 
+    {% if perms.recupero.view_factura or perms.recupero.view_tipodocumentoanexo or perms.recupero.view_tipoprestacion %}
     <li>
         <a href="#menu_recupero" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">Recupero</a>
         <ul class="collapse list-unstyled" id="menu_recupero">
         {% if perms.recupero.view_factura %}
-        <liview
+        <li>
             <a href="{% url 'recupero.factura.lista-pendientes-envio' %}">Facturación pendiente de envío</a>
         </li>
             
@@ -207,4 +220,5 @@ Centro de salud activo
         {% endif %}
         </ul>
     </li>
+    {% endif %}
 </ul>


### PR DESCRIPTION
@avdata99 fijate que te parece esta forma de ver que <li> mostrar del menu, aunque estan bien los permisos de las acciones internas a cada solapa. A veces se mostraban las solapas vacias porque el usuario no tenia permiso para ninguna de las tareas de adentro.

Otra opciones que se me ocurre, que me parece un poco mas prolija es generar permisos para las solapas principales del menu del estilo profesional.can_view_menu, turnos.can_view_menu.