### PR TITLE
Fixes en Agendar Turno como ciudadano

### DIFF
--- a/calendario/forms.py
+++ b/calendario/forms.py
@@ -115,24 +115,20 @@ class TurnoForm(forms.ModelForm):
     def update(self, data, *args, **kwargs):
         paciente = Paciente.objects.filter(numero_documento=data['paciente']).first()
         if paciente is None:
-            if data['buscar_data']:
-                save, result = Paciente.create_from_sisa(data['paciente'])
-                if not save and ('nombres' in data and 'apellidos' in data):
-                    paciente = Paciente.objects.create(
-                        numero_documento=data['paciente'],
-                        nombres=data['nombres'],
-                        apellidos=data['apellidos'],
-                    )
-                    self.instance.paciente = paciente
-                    self.instance.solicitante = data['solicitante']
-                    self.instance.estado = 1
-                    self.instance.save()
-                    return True, self.instance
-                else:
-                    return save, result
+            save, result = Paciente.create_from_sisa(data['paciente'])
+            if not save and ('nombres' in data and 'apellidos' in data):
+                paciente = Paciente.objects.create(
+                    numero_documento=data['paciente'],
+                    nombres=data['nombres'],
+                    apellidos=data['apellidos'],
+                )
+                self.instance.paciente = paciente
+                self.instance.solicitante = data['solicitante']
+                self.instance.estado = 1
+                self.instance.save()
+                return True, self.instance
             else:
-                error = {'paciente':'El dni ingresado no corresponde a un paciente del sistema'}
-                return False, error
+                return save, result
         else:
             self.instance.paciente = paciente
             self.instance.solicitante = data['solicitante']

--- a/calendario/templates/calendario-agregar.html
+++ b/calendario/templates/calendario-agregar.html
@@ -190,7 +190,9 @@
         <div class="form-group">
           <label for="dni" class="col-form-label">DNI Paciente:</label>
           <input class="form-control" id="dni"></input>
-          <span class="help-block" id="dni-error" style="display: none;">El dni es incorrecto</span>
+          <span class="help-block" id="dni-error" style="display: none;">
+            Tu historia clínica no ha sido inicializada, luego de que recibas la próxima atención esto estará resuelto
+          </span>
         </div>
         <input id="turn_pk" hidden/>
       </div>

--- a/calendario/views.py
+++ b/calendario/views.py
@@ -181,7 +181,6 @@ def confirm_turn(request, pk):
     instance = get_object_or_404(Turno, id=pk)
     form_data = json.loads(request.body)
     form_data['solicitante'] = request.user
-    form_data['buscar_data'] = False
     form = TurnoForm(form_data, instance=instance)
     save, result = form.update(form_data)
     if save:
@@ -264,7 +263,6 @@ def gestion_turno(request, pk):
     instance = get_object_or_404(Turno, id=pk)
     form_data = json.loads(request.body)
     form_data['solicitante'] = request.user
-    form_data['buscar_data'] = True
     form = TurnoForm(form_data, instance=instance)
     save, result = form.update(form_data)
     if save:


### PR DESCRIPTION
- Se intenta cargar al paciente por renaper si no existe en la bd
-Se cambio el error que se le muestra al ciudadano si no se pudo cargar al paciente en el turno