### PR TITLE
Agregados tests para administrativos

### DIFF
--- a/centros_de_salud/views.py
+++ b/centros_de_salud/views.py
@@ -92,7 +92,7 @@ class CentroDeSaludDetailView(PermissionRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['title'] = 'Centros de Saludos'
+        context['title'] = 'Centros de Salud'
         context['title_url'] = 'centros_de_salud.lista'
         context['GOOGLE_API_LEY'] = settings.GOOGLE_API_KEY
         return context

--- a/usuarios/tests.py
+++ b/usuarios/tests.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from core.base_permission import start_roles_and_permissions, create_test_data
 from centros_de_salud.models import CentroDeSalud
+from calendario.forms import TurnoForm
 
 
 class FullUserMixin:
@@ -42,3 +43,23 @@ class AdministrativosTest(TestCase, FullUserMixin):
         
         self.assertTrue(len(CS_Permitidos) == 1)
         self.assertEqual('Centro de Salud 1', CS_Permitidos[0].nombre)
+    
+    def test_especialidades_permitidas_form_turno(self):
+        ''' Usuario `administrativo1` solamente puede agregar turnos de 
+            Especialidades en Centros de Salud permitidos '''
+        
+        self.client.login(username=self.user_admin_1, password=self.user_admin_1)
+
+        # Instanciar el formulario de Turnos para nuestro usuario
+        form = TurnoForm(user=self.user_admin_1)
+
+        # Obtener la especialidad (Servicio de un centro de salud) 
+        # permitida para este usuario
+        
+        # El método get() devuelve un error si existe más de 1 objeto
+        servicio = form.fields['servicio'].queryset.get()
+
+        # El usuario administrativo1 solo puede agendar turnos
+        # de especialidades del CS 1 que es el que tiene asignado
+        self.assertEqual(servicio.centro.nombre, 'Centro de Salud 1')
+        self.assertEqual(servicio.especialidad.nombre, 'Especialidad 1')

--- a/usuarios/tests.py
+++ b/usuarios/tests.py
@@ -1,3 +1,44 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from core.base_permission import start_roles_and_permissions, create_test_data
+from centros_de_salud.models import CentroDeSalud
 
-# Create your tests here.
+
+class FullUserMixin:
+    def create_users_and_groups(self):
+        # Crear roles y permisos
+        start_roles_and_permissions()
+        create_test_data()
+
+class AdministrativosTest(TestCase, FullUserMixin):
+
+    def setUp(self):
+        
+        self.client = Client()
+        self.create_users_and_groups()
+        self.user_admin_1 = User.objects.filter(username='administrativo1').get()
+    
+    def test_login_administrativo(self):
+
+        # Request sin loguearse
+        response = self.client.get('/turnos/')
+        self.assertRedirects(response, '/accounts/login/?next=/turnos/') 
+
+        # Login con user administrativo1
+        self.client.login(username=self.user_admin_1, password=self.user_admin_1)
+
+        response = self.client.get('/turnos/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_centro_salud_permitido(self):
+        ''' Usuario `administrativo1` solo puede ver el centro de salud que se le asignó '''
+
+        self.client.login(username=self.user_admin_1, password=self.user_admin_1)
+
+        response = self.client.get('/turnos/')
+        
+        # Sacar CS permitidos del context (list)
+        CS_Permitidos = response.context['user__centros_de_salud_autorizados']
+        
+        self.assertTrue(len(CS_Permitidos) == 1)
+        self.assertEqual('Centro de Salud 1', CS_Permitidos[0].nombre)


### PR DESCRIPTION
- [x] Asegurarse que cada administrativo solo puede ver el centro de salud que se le asigno (por ej, administrativo3 solo puede ver el centro de salud 3)

- [x] Asegurarse que solo se muestran las especialdiades que corresponden a los servicios del centro de salud que el administrativo tiene activado

- [x] Asegurarse que los profesionales listados sean los que corresponden a la especialidad elegida.