### PR TITLE
Urls corregidas en todas las apps del sistema.

### DIFF
--- a/calendario/urls.py
+++ b/calendario/urls.py
@@ -13,9 +13,9 @@ urlpatterns = [
     url(r'^agendar/$', agendar, name='calendario.agendar'),
     url(r'^confirm_turn/(?P<pk>\d+)/$', confirm_turn, name='calendario.confirm'),
     url(r'^edit_turn/(?P<pk>\d+)/$', edit_turn, name='calendario.edit_turn'),
-    url(r'^mis_turnos$', mis_turnos, name='calendario.mis_turnos'),
+    url(r'^mis_turnos/$', mis_turnos, name='calendario.mis_turnos'),
     url(r'^cancelar_turn/(?P<pk>\d+)/$',cancelar_turno, name='calendario.cancelar_turn'),
-    url(r'^gestionar_turnos',gestion_turnos, name='calendario.gestion_turnos'),
+    url(r'^gestionar_turnos/$',gestion_turnos, name='calendario.gestion_turnos'),
     url(r'^gestionar_turno/(?P<pk>\d+)/$', gestion_turno, name='calendario.gestion_turno'),
     url(r'^crear_sobreturno/(?P<pk>\d+)/$', crear_sobreturno, name='calendario.crear_sobreturno'),
 ]

--- a/centros_de_salud/urls.py
+++ b/centros_de_salud/urls.py
@@ -45,7 +45,7 @@ urlpatterns = [
         name="centros_de_salud.servicios",
     ),
     url(
-        r"^crear-servicio.html",
+        r"^crear-servicio.html$",
         ServicioCreateView.as_view(),
         name="centros_de_salud.servicios.create",
     ),
@@ -67,7 +67,7 @@ urlpatterns = [
         name="centros_de_salud.especialidades",
     ),
     url(
-        r"^crear-especialidad.html",
+        r"^crear-especialidad.html$",
         EspecialidadCreateView.as_view(),
         name="centros_de_salud.especialidades.create",
     ),
@@ -89,7 +89,7 @@ urlpatterns = [
         name="centros_de_salud.profesionales-en-servicio",
     ),
     url(
-        r"^crear-profesional-en-servicio.html",
+        r"^crear-profesional-en-servicio.html$",
         ProfesionalesEnServicioCreateView.as_view(),
         name="centros_de_salud.profesionales-en-servicio.create",
     ),

--- a/core/urls.py
+++ b/core/urls.py
@@ -12,12 +12,12 @@ from core.views import (CIE10Autocomplete,
 
 urlpatterns = [
     path(
-        r"servicio-autocomplete",
+        r"servicio-autocomplete/",
         ServicioAutocomplete.as_view(),
         name="servicio-autocomplete",
     ),
     path(
-        r"carpeta-familiar-autocomplete",
+        r"carpeta-familiar-autocomplete/",
         CarpetaFamiliarAutocomplete.as_view(),
         name="carpeta-familiar-autocomplete",
     ),

--- a/especialidades/urls.py
+++ b/especialidades/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
         name="especialidades.medidas_anexas",
     ),
     url(
-        r"^crear-medida_anexa.html",
+        r"^crear-medida_anexa.html$",
         MedidaAnexaCreateView.as_view(),
         name="especialidades.medidas_anexas.create",
     ),
@@ -47,7 +47,7 @@ urlpatterns = [
         name="especialidades.medidas-anexas-en-especialidades",
     ),
     url(
-        r"^crear-medidas-anexas-en-especialidades.html",
+        r"^crear-medidas-anexas-en-especialidades.html$",
         MedidasAnexasEspecialidadCreateView.as_view(),
         name="especialidades.medidas-anexas-en-especialidades.create",
     ),

--- a/ggg/urls.py
+++ b/ggg/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
     url(r'^hsuper/$', SuperAdminHome.as_view(), name='super.home'),
     url(r'^hrecupero/$', RecuperoHome.as_view(), name='recupero.home'),
     url(r'^hdata/$', DataHome.as_view(), name='data.home'),
-    url(r'^home$', choice_homepage, name='home'),
+    url(r'^home/$', choice_homepage, name='home'),
 ] 
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/pacientes/templates/pacientes/consulta_listview.html
+++ b/pacientes/templates/pacientes/consulta_listview.html
@@ -4,15 +4,6 @@
 {% endblock %}
 
 {% block content %}
-    {% if messages %}
-        <div class="col-lg-3 color03">
-            <ul class="messages">
-                {% for message in messages %}
-                    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-                {% endfor %}
-            </ul>
-        </div>
-    {% endif %}
     <h2>Listado de consultas</h2>
     {% for consulta in consultas %}
         <nav class="navbar navbar-expand-lg navbar-light bg-light">

--- a/pacientes/urls.py
+++ b/pacientes/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     ),
     
     path(
-        r"<int:dni>/historia",
+        r"<int:dni>/historia/",
         ConsultaListView.as_view(),
         name="pacientes.consulta.lista",
     ),
@@ -27,7 +27,7 @@ urlpatterns = [
         name="pacientes.consulta.detalle",
     ),
     path(
-        r"crear-carpeta-familiar",
+        r"crear-carpeta-familiar/",
         CarpetaFamiliarCreateView.as_view(),
         name="pacientes.carpeta-familiar.crear",
     ),

--- a/recupero/urls.py
+++ b/recupero/urls.py
@@ -18,8 +18,8 @@ from .views_tipo_documento_anexo import (TipoDocumentoAnexoListView,
 from .views_anexo2 import Anexo2View
 
 urlpatterns = [
-    url(
-        r"^facturacion$",
+    path(
+        r"facturacion/",
         FacturaListView.as_view(),
         name="recupero.facturas",
     ),
@@ -34,7 +34,7 @@ urlpatterns = [
         name="recupero.factura.edit",
     ),
     path(
-        r"crear-factura",
+        r"crear-factura/",
         FacturaCreateView.as_view(),
         name="recupero.factura.create",
     ),
@@ -59,8 +59,8 @@ urlpatterns = [
         name="recupero.tipos-prestacion.edit",
     ),
 
-    url(
-        r"^tipo-de-documentacion-anexa.html$",
+    path(
+        r"tipo-de-documentacion-anexa.html",
         TipoDocumentoAnexoListView.as_view(),
         name="recupero.tipos-doc-anexo",
     ),
@@ -86,4 +86,3 @@ urlpatterns = [
     ),
     
 ]
-

--- a/usuarios/urls.py
+++ b/usuarios/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
         name="usuarios.en-centro-de-salud",
     ),
     url(
-        r"^crear-en-centro-de-salud.html",
+        r"^crear-en-centro-de-salud.html$",
         UsuarioEnCentroDeSaludCreateView.as_view(),
         name="usuarios.en-centro-de-salud.create",
     ),


### PR DESCRIPTION
El template [consulta_listview.html](https://github.com/cluster311/ggg/blob/a9d808408222ae326bde61d8ae8e2cf091415950/pacientes/templates/pacientes/consulta_listview.html#L11) muestra mensajes de inicio o cierre de sesión.

**URL:** `localhost:8000/pacientes/1/historia` donde 1 es el DNI

![imagen](https://user-images.githubusercontent.com/19599150/80557116-38e2f680-89ac-11ea-8c8e-54282f654981.png)
***
**Propuesta:** Me parece que podría eliminar esas líneas ya que es el único template que muestra esos mensajes. Además es información irrelevante para esa página.

fixes #175 