### PR TITLE
cambio de forma de guardar las medidas anexas

### DIFF
--- a/especialidades/forms.py
+++ b/especialidades/forms.py
@@ -1,7 +1,10 @@
 from dal import autocomplete
 from django import forms
-from .models import (MedidaAnexa, 
-                     MedidasAnexasEspecialidad, 
+from django.forms import inlineformset_factory
+
+from pacientes.models import Consulta
+from .models import (MedidaAnexa,
+                     MedidasAnexasEspecialidad,
                      MedidaAnexaEnConsulta
                     )
 
@@ -31,15 +34,18 @@ class MedidasAnexasEspecialidadForm(forms.ModelForm):
 
 class MedidaAnexaEnConsultaForm(forms.ModelForm):
 
-    valor = forms.DecimalField(widget=forms.NumberInput(attrs={'step': 0.25})) 
-    
+    valor = forms.DecimalField(widget=forms.NumberInput(attrs={'step': 0.25}))
+    medida = forms.ModelChoiceField(queryset=MedidaAnexa.objects.all(), widget=forms.HiddenInput())
+
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)
-        obligatorio = kwargs.pop('obligatorio', False)
-        super().__init__(*args, **kwargs)  
-        self.fields['valor'].required = obligatorio    
-    
+        super().__init__(*args, **kwargs)
+        medida = MedidaAnexa.objects.get(id=self.initial['medida'])
+        self.fields['valor'].label = medida.nombre
+
     class Meta:
         model = MedidaAnexaEnConsulta
-        fields = ['valor']
+        fields = ['valor', 'medida']
 
+
+MedidaAnexaEnConsultaFormset = inlineformset_factory(Consulta, MedidaAnexaEnConsulta, form=MedidaAnexaEnConsultaForm, extra=0, can_delete=False)

--- a/pacientes/templates/pacientes/evolucion.html
+++ b/pacientes/templates/pacientes/evolucion.html
@@ -35,21 +35,9 @@
           <small>Separados por comas</small></p>
 
         <h4>Medidas anexas</h4>
-          {% for medida in medidas_en_consulta %}
-            <p> {{ medida.medida_en_consulta.medida.nombre }} 
-              <input 
-                type="number" 
-                value="{{ medida.medida_en_consulta.valor|unlocalize }}" 
-                step="10.00" required="true" 
-                name="medida_{{ medida.medida_en_consulta.id}}">
-              
-<small> {{ medida.medida_en_consulta.medida.observaciones_para_el_que_mide }} {{ medida.medida_en_especialidad.observaciones_para_el_que_mide }}</small>
-            </p>
-            
-          {% empty %}
-            <p>No hay medidas anexas para esta especialdiad</p>
-          {% endfor %}
-
+          <div class="{{ p }}-form">
+            {{ medidas_frm|crispy }}
+          </div>
       </div>
       <div class="col-6 col-md-6">
         <div>

--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -166,7 +166,6 @@ class EvolucionUpdateView(ConsultaMixin,
     def get_success_url(self):
         return reverse(
             "profesionales.home",
-            kwargs=({"dni": self.object.paciente.numero_documento}),
         )
 
 

--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -14,7 +14,7 @@ from django.template import RequestContext
 from django.conf import settings
 from .models import Consulta, CarpetaFamiliar
 from especialidades.models import MedidasAnexasEspecialidad, MedidaAnexaEnConsulta
-from especialidades.forms import MedidaAnexaEnConsultaForm
+from especialidades.forms import MedidaAnexaEnConsultaForm, MedidaAnexaEnConsultaFormset
 from calendario.models import Turno
 from .forms import (EvolucionForm, ConsultaForm,
                    RecetaFormset, DerivacionFormset, 
@@ -95,20 +95,13 @@ class ConsultaMixin:
         medidas_a_tomar = MedidasAnexasEspecialidad.objects.filter(
             especialidad=consulta.especialidad
         )
-        medidas_en_consulta = []
         for medida in medidas_a_tomar:
-            medida_en_consulta, created = MedidaAnexaEnConsulta.objects.get_or_create(
+            MedidaAnexaEnConsulta.objects.get_or_create(
                 consulta=consulta,
                 medida=medida.medida
                 )
-            
-            frm = MedidaAnexaEnConsultaForm(instance=medida_en_consulta, obligatorio=medida.obligatorio)
-            medidas_en_consulta.append({'medida_en_consulta': medida_en_consulta,
-                                        'frm': frm,
-                                        'medida_en_especialidad': medida})
-        
-        context['medidas_en_consulta'] = medidas_en_consulta
-
+        context["recetas_frm"] = RecetaFormset(data, prefix='Recetas', instance=instance)
+        context["medidas_frm"] = MedidaAnexaEnConsultaFormset(data, prefix='Medidas', instance=instance)
         return context
 
     def form_valid(self, form):
@@ -117,6 +110,7 @@ class ConsultaMixin:
         rs = context["recetas_frm"]
         ds = context["derivaciones_frm"]
         ps = context["prestaciones_frm"]
+        ms = context["medidas_frm"]
 
         self.object = form.save()
         logger.info(f'Pasando el turno {self.object.turno} a "atendido"')
@@ -138,21 +132,9 @@ class ConsultaMixin:
         
         # ISSUE usar MedidaAnexaEnConsultaForm
         # https://github.com/cluster311/ggg/issues/120
-        data = context["data"]
-        for field, value in data.items():
-            if field.startswith('medida_'):
-                medida_en_consulta_id = field.split('_')[1]
-                medida_en_consulta = MedidaAnexaEnConsulta.objects.get(pk=medida_en_consulta_id)
-
-                try:
-                    a = float(value)
-                except:
-                    error = 'Valor inválido para {medida_en_consulta.medida_en_consulta.nombre}'
-                    logger.error(error)
-                    # form.add_error(None, error)
-                else:
-                    medida_en_consulta.valor = value
-                    medida_en_consulta.save()
+        if ms.is_valid():
+            ms.instance = self.object
+            ms.save()
 
         return super().form_valid(form)
 


### PR DESCRIPTION
se borro lo que era un input en crudo, tambien lo que era formularios, había una mezcla de cosas que no se usaban. se utilizaron los formularios inline formset
algunas cosas a tener en cuenta
- los formularios al estar previamente creados deberíamos hacer que los que sean obligatorios sean > 0. en este momento es lo mismo lo obligatorio porque estan todos creados y en 0

- falta agregar un texto en pequeño de la medida con info adicional