### PR TITLE
Ahora se muestra CS, especialidad y profesional en listado de facturas

### DIFF
--- a/recupero/templates/recupero/factura_list.html
+++ b/recupero/templates/recupero/factura_list.html
@@ -15,39 +15,39 @@
         </tr>
     </thead>
     <tbody>
-        {% for cs in object_list %}
+        {% for factura in object_list %}
         <tr>
             <td>
-                <a role="button" class="btn btn-warning btn-sm active" data-target="#detalle_factura_{{ cs.id }}" data-toggle="collapse"
+                <a role="button" class="btn btn-warning btn-sm active" data-target="#detalle_factura_{{ factura.id }}" data-toggle="collapse"
                 aria-expanded="false">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M6 9l6 6 6-6" /></svg>
             </a>
             </td>
-            <td scope="row">{{ cs.get_estado_display }}</td>
-            <td scope="row">{{ cs.created|date:"Y/m/d" }}</td>
-            <td scope="row">{{ cs.obra_social|default_if_none:"Sin definir" }}</td>
-            <td scope="row">{{ cs.consulta.centro_de_salud }}</td>
-            <td scope="row">{{ cs.consulta.especialidad }}</td>
+            <td scope="row">{{ factura.get_estado_display }}</td>
+            <td scope="row">{{ factura.created|date:"Y/m/d" }}</td>
+            <td scope="row">{{ factura.obra_social|default:"Sin definir" }}</td>
+            <td scope="row">{{ factura.centro_de_salud }}</td>
+            <td scope="row">{{ factura.especialidad|default:"Sin definir" }}</td>
             <td scope="row">
                 <a role="button" class="btn btn-warning btn-sm active"
-                    href="{% url 'recupero.anexo2' factura_id=cs.id %}">Factura</a>
+                    href="{% url 'recupero.anexo2' factura_id=factura.id %}">Anexo II</a>
                 {% if perms.recupero.change_factura %}
                 <a role="button" class="btn btn-warning btn-sm active"
-                    href="{% url 'recupero.factura.edit' pk=cs.id %}">Editar</a>
+                    href="{% url 'recupero.factura.edit' pk=factura.id %}">Editar</a>
                 {% endif %}
             </td>
         </tr>
         <tr>
             <td class="p-0" colspan="8">
-                <div id="detalle_factura_{{ cs.id }}" class="m-2 collapse">
+                <div id="detalle_factura_{{ factura.id }}" class="m-2 collapse">
                     <span>
-                        <b>Nro de factura:</b> {{ cs.id }} -   
-                        <b>Profesional:</b> {{ cs.consulta.profesional }} -   
-                        <b>CIE10 Principal:</b> {{ cs.consulta.codigo_cie_principal }} -   
+                        <b>Nro de factura:</b> {{ factura.id }} -   
+                        <b>Profesional:</b> {{ factura.profesional|default:"Sin definir" }} -   
+                        <b>CIE10 Principal:</b> {{ factura.codigo_cie_principal }} -   
                         <b>Total factura:</b> $ 123
-                        <a role="button" class="btn btn-warning btn-sm active" href="{% url 'recupero.factura.detail' pk=cs.id %}">Más detalles</a>
+                        <a role="button" class="btn btn-warning btn-sm active" href="{% url 'recupero.factura.detail' pk=factura.id %}">Más detalles</a>
                     </span>
                 </div>
             </td>


### PR DESCRIPTION
Fixes #249 

Hay que mergear el PR #253 antes ya que se agregan campos al modelo Factura.

Se pueden agregar `default` a todos los campos pero no sé hasta que punto es útil. También se pueden sacar.