### PR TITLE
Ahora la fecha de atención no muestra la hora

### DIFF
--- a/pacientes/forms.py
+++ b/pacientes/forms.py
@@ -5,7 +5,7 @@ from django.forms.models import inlineformset_factory
 from django.utils.translation import gettext_lazy as _
 from cie10_django.models import CIE10
 
-from calendario.widgets import DateTimePicker, DatePicker
+from calendario.widgets import DatePicker
 from pacientes.models import (Consulta, Paciente, Receta, Derivacion,
                               CarpetaFamiliar)
 from profesionales.models import Profesional

--- a/recupero/forms.py
+++ b/recupero/forms.py
@@ -1,7 +1,7 @@
 from cie10_django.models import CIE10
 from django import forms
 from django.forms import inlineformset_factory
-from calendario.widgets import DateTimePicker
+from calendario.widgets import DatePicker
 from centros_de_salud.models import CentroDeSalud, Especialidad
 from obras_sociales.models import ObraSocial
 from pacientes.models import Paciente
@@ -102,7 +102,7 @@ class FacturaForm(forms.ModelForm):
                   'codigo_cie_principal',
                   'codigos_cie_secundarios',
                    )
-        widgets = {'fecha_atencion': DateTimePicker()}
+        widgets = {'fecha_atencion': DatePicker()}
 
 
 FacturaPrestacionFormSet = inlineformset_factory(Factura, FacturaPrestacion, form=FacturaPrestacionForm, extra=1)


### PR DESCRIPTION
Fixes #259 

Ahora el selector de fecha de atención usa el widget `DatePicker`

![imagen](https://user-images.githubusercontent.com/19599150/90566084-418b5280-e17e-11ea-89dc-710d9bf7f47b.png)

PD: Lo eliminé de `pacientes/forms.py` porque no se usaba más