### PR TITLE
244 grabacion facturas desde consultas

### DIFF
--- a/core/base_permission.py
+++ b/core/base_permission.py
@@ -122,7 +122,7 @@ def create_test_data():
 
     for x in range(1, 4):
         # crear centros de salud y especialidades
-        cs, created = CentroDeSalud.objects.get_or_create(nombre=f"Centro de Salud {x}")
+        cs, created = CentroDeSalud.objects.get_or_create(nombre=f"Centro de Salud {x}", codigo_hpgd=f"{x}.{x}")
         es, created = Especialidad.objects.get_or_create(nombre=f"Especialidad {x}")
         # crear un servicio en ese centro de salud para esa especialidad
         se, created = Servicio.objects.get_or_create(centro=cs, especialidad=es)

--- a/recupero/models.py
+++ b/recupero/models.py
@@ -232,9 +232,6 @@ class Factura(TimeStampedModel):
         try:
             hospital = self.centro_de_salud.as_anexo2_json()
 
-            # TODO, no permitido
-            hospital['codigo_hpgd'] = hospital['codigo_hpgd'] or 'DESC'
-
         except AttributeError:
             errores_generacion['hospital'] = "Debe asignar un centro de salud en la factura"
             hospital = None

--- a/recupero/views.py
+++ b/recupero/views.py
@@ -48,8 +48,8 @@ class FacturaListView(PermissionRequiredMixin, ListView):
                 Q(consulta__centro_de_salud__nombre__icontains=q) |
                 Q(obra_social__nombre__icontains=q)
                 )
-        # mostrar prinmero los ultimos modificados
-        objects = objects.order_by('-modified')
+        # Excluir las facturas nuevas y ordernar por últimas modificadas
+        objects = objects.exclude(estado=Factura.EST_NUEVO).order_by('-modified')
         return objects
     
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Fixes #244 

Verificar si estos items todavía son relevantes para meterlos en este PR.

> - La factura pasa a un estado que si es visible por el operador y donde la consulta no va a afectar más a su factura relacionada
> - Pasar la factura a un estado diferente donde no es más afectada por las actualziaciones de la consulta y ya es visible por los operadores de recupero