### PR TITLE
Excluir las facturas con estado = Nueva factura

### DIFF
--- a/recupero/views.py
+++ b/recupero/views.py
@@ -48,8 +48,8 @@ class FacturaListView(PermissionRequiredMixin, ListView):
                 Q(consulta__centro_de_salud__nombre__icontains=q) |
                 Q(obra_social__nombre__icontains=q)
                 )
-        # mostrar prinmero los ultimos modificados
-        objects = objects.order_by('-modified')
+        # Excluir las facturas nuevas y ordernar por últimas modificadas
+        objects = objects.exclude(estado=Factura.EST_NUEVO).order_by('-modified')
         return objects
     
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Fixes #244

Verificar si estos items todavía son relevantes para meterlos en este PR.

> ~- La factura pasa a un estado que si es visible por el operador y donde la consulta no va a afectar más a su factura relacionada~
> ~- Pasar la factura a un estado diferente donde no es más afectada por las actualziaciones de la consulta y ya es visible por los operadores de recupero~
