### PR TITLE
numero de afiliado cuando se carga una nueva obrasocial paciente

### DIFF
--- a/obras_sociales/views.py
+++ b/obras_sociales/views.py
@@ -157,7 +157,7 @@ def ObraSocialPacienteCreatePopup(request, paciente=None):
         if form.is_valid():
             instance = form.save()
             return HttpResponse(
-                '<script>opener.closePopup(window, "%s", "%s", "#id_obra_social");</script>' % (instance.obra_social.pk, instance.obra_social))
+                '<script>opener.closePopup(window, "%s", "%s", "#id_obra_social","%s");</script>' % (instance.obra_social.pk, instance.obra_social, instance.numero_afiliado))
     form = ObraSocialPacienteCreatePopUp(initial={'paciente': paciente})
     return render(request, "obras_sociales/obrasocial_paciente_createview.html", {"form": form})
 

--- a/recupero/templates/recupero/factura_create_form.html
+++ b/recupero/templates/recupero/factura_create_form.html
@@ -186,11 +186,18 @@
                     },
                 });
         }
-        function closePopup(win, newID, newRepr, id) {
+        function closePopup(win, newID, newRepr, id, numero) {
             $(id).append('<option value=' + newID + ' selected >' + newRepr + '</option>')
             win.close();
+            if (numero != '' && numero != 'None'){
+                $("#id_numero_afiliado").val(numero).prop("disabled", true);
+            }
+            else{
+                $("#id_numero_afiliado").val("").prop("disabled", false).attr('placeholder', 'Ingrese numero de carnet de paciente');
+            }
             $("#add_obrasocial").attr("href", "{%  url 'ObraSocialPacienteCreate' paciente=None %}".replace('None',$('#id_paciente').val()));
         }
+
         function closePopupCleanField(win, pk, doc){
             $("#id_paciente").val(pk);
             $("#id_dni").val(doc).prop("disabled", true);


### PR DESCRIPTION
cuando se carga una nueva obra social paciente, con el + en el formulario de recupero, ahora muestra el numero de afiliado cargado o pedirle al usuario que lo cargue. 