### PR TITLE
filtrado de obra social repetida

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -44,10 +44,14 @@ class ObraSocialAutocomplete(autocomplete.Select2QuerySetView):
     """
 
     def get_queryset(self):
-        qs = ObraSocialPaciente.objects.filter(paciente_id=self.forwarded.get('paciente', None))
+        codigos=[]
+        qs = ObraSocialPaciente.objects.select_related('obra_social').filter(paciente_id=self.forwarded.get('paciente', None))
         osp = []
         for q in qs:
-            osp.append(q.obra_social)
+            codigo = q.obra_social.codigo
+            if not codigo in codigos:
+                codigos.append(codigo)
+                osp.append(q.obra_social)
         return osp
 
 

--- a/obras_sociales/views.py
+++ b/obras_sociales/views.py
@@ -164,7 +164,7 @@ def ObraSocialPacienteCreatePopup(request, paciente=None):
 
 def BuscarObraSocialPaciente(request, id_paciente, id_obra_social):
     if ObraSocialPaciente.objects.filter(paciente_id=id_paciente, obra_social_id=id_obra_social).exists():
-        osp = ObraSocialPaciente.objects.get(paciente_id=id_paciente, obra_social_id=id_obra_social)
+        osp = ObraSocialPaciente.objects.filter(paciente_id=id_paciente, obra_social_id=id_obra_social).order_by('-id')[0]
         data = {
             "encontrado": True,
             "numero_afiliado": osp.numero_afiliado


### PR DESCRIPTION
aparece una vez sola la obra social, si la tiene tanto de SSS y SISA, 
cuando se selecciona una en el formulario de recupero va a buscar el ultimo cargado, para traer el numero de afiliado, si es que lo tiene