### PR TITLE
Anexo2 se puede imprimir sin datos de la empresa

### DIFF
--- a/obras_sociales/models.py
+++ b/obras_sociales/models.py
@@ -110,13 +110,13 @@ class ObraSocialPaciente(models.Model):
                     'parentesco': 'conyuge'
                 }
         """
-        emision_dia = 1 if self.fecha_de_emision is None else self.fecha_de_emision.day
-        emision_mes = 2 if self.fecha_de_emision is None else self.fecha_de_emision.month
-        emision_ano = 2019 if self.fecha_de_emision is None else self.fecha_de_emision.year
+        emision_dia = None if self.fecha_de_emision is None else self.fecha_de_emision.day
+        emision_mes = None if self.fecha_de_emision is None else self.fecha_de_emision.month
+        emision_ano = None if self.fecha_de_emision is None else self.fecha_de_emision.year
 
-        vto_dia = 1 if self.fecha_de_vencimiento is None else self.fecha_de_vencimiento.day
-        vto_mes = 2 if self.fecha_de_vencimiento is None else self.fecha_de_vencimiento.month
-        vto_ano = 2020 if self.fecha_de_vencimiento is None else self.fecha_de_vencimiento.year
+        vto_dia = None if self.fecha_de_vencimiento is None else self.fecha_de_vencimiento.day
+        vto_mes = None if self.fecha_de_vencimiento is None else self.fecha_de_vencimiento.month
+        vto_ano = None if self.fecha_de_vencimiento is None else self.fecha_de_vencimiento.year
 
         ret = {
             'codigo_rnos': self.obra_social.codigo,

--- a/pacientes/models.py
+++ b/pacientes/models.py
@@ -145,7 +145,7 @@ class Paciente(Persona):
         elif self.sexo == 'femenino':
             sexo = 'F'
         
-        edad = 0 if self.edad is None else self.edad
+        edad = self.edad
 
         tmp = self.tipo_documento.upper()
         if tmp == 'DOCUMENTO UNICO' or tmp == 'DU':

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ cie>=0.208
 fastkml>=0.11
 django_tinymce>=2.8.0
 oss-ar>=0.131
-anexo2>=1.0.20
+anexo2>=1.0.22
 sss-beneficiarios-hospitales>=0.8.120


### PR DESCRIPTION
Fixes #312 

 - Ahora la empresa se obtiene de la factura y puede tener datos vacíos
 - Fecha de atención puede estar vacía
 - Edad del paciente puede estar vacía
 - Fecha de emisión/vencimiento de OS pueden estar vacías

### :warning: Mergear PR https://github.com/cluster311/Anexo2/pull/12